### PR TITLE
Update example config

### DIFF
--- a/configs/examples/tardis_example.yml
+++ b/configs/examples/tardis_example.yml
@@ -1,17 +1,13 @@
 # Example YAML configuration for TARDIS
-# Currently only simple1d is allowed
-
 tardis_config_version: v1.0
-
 
 supernova:
   luminosity_requested: 9.44 log_lsun
   time_explosion: 13 day
   #distance: 24.2 Mpc
 
-
+# standard atomic data base; get it from the tardis-refdata repository
 atom_data: kurucz_cd23_chianti_H_He.h5
-
 
 model:
   structure:
@@ -45,7 +41,6 @@ model:
     Ar: 0.04
     Ca: 0.03
 
-
 plasma:
   #initial_t_inner: 10000 K
   #initial_t_rad: 10000 K
@@ -57,11 +52,16 @@ plasma:
   # line_interaction_type - currently supported are scatter, downbranch and macroatom
   line_interaction_type: macroatom
 
-
 montecarlo:
   seed: 23111963
   no_of_packets: 4.0e+4
   iterations: 20
+  # Number of threads used in OMP mode; uncomment if you want to control the
+  # OMP behaviour via the config; otherwise the maximum available number of
+  # threads is used or the number specified in the OMP_NUM_THREADS environment
+  # variable
+  # --------
+  #nthreads: 1
 
   black_body_sampling:
     start: 1 angstrom
@@ -79,9 +79,7 @@ montecarlo:
     t_inner:
       damping_constant: 1.0
 
-
 spectrum:
   start: 500 angstrom
   stop: 20000 angstrom
   num: 10000
-


### PR DESCRIPTION
This PR makes some cosmetic changes to the tardis_example config and adds an explanation of the behaviour of the ``nthreads`` option.