### PR TITLE
Update reference data for formal integral tests

### DIFF
--- a/unit_test_data.h5
+++ b/unit_test_data.h5
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1aa2daddf4d35ec957c08eaf51801e7650fc31997cd464ed8c9c83ff20fae7f8
-size 92628228
+oid sha256:dbe1fa09b966db05de349ed2f6d3f77f9a86fe9a7ce07659c215a718cabf8760
+size 103761668


### PR DESCRIPTION
This PR updates the unit test reference data to be compatible with the changes of Tardis PR #850.