### PR TITLE
Update reference data for PR #688

### DIFF
--- a/unit_test_data.h5
+++ b/unit_test_data.h5
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:dbe1fa09b966db05de349ed2f6d3f77f9a86fe9a7ce07659c215a718cabf8760
+oid sha256:5a39585c4bc6bc37528145ae3d0a12b2791079eb5e5d4206fd7b98a7e3c1bd43
 size 103761668


### PR DESCRIPTION
This PR updates the unit tests refdata to be compatible with the changes of Tardis PR #688.