### PR TITLE
Create infrastructure and reference data for integration tests

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,3 +6,8 @@ atom_data/kurucz_cd23_chianti_H_He.h5 filter=lfs diff=lfs merge=lfs -text
 atom_data/chianti_He.h5 filter=lfs diff=lfs merge=lfs -text
 unit_test_data.h5 filter=lfs diff=lfs merge=lfs -text
 plasma_reference/reference_data.h5 filter=lfs diff=lfs merge=lfs -text
+integration/reference_lesspackets/at.h5 filter=lfs diff=lfs merge=lfs -text
+integration/reference_lesspackets/paper1_downbranch.h5 filter=lfs diff=lfs merge=lfs -text
+integration/reference_lesspackets/paper1_macroatom.h5 filter=lfs diff=lfs merge=lfs -text
+integration/reference_lesspackets/paper1_scatter.h5 filter=lfs diff=lfs merge=lfs -text
+integration/reference_lesspackets/w7.h5 filter=lfs diff=lfs merge=lfs -text

--- a/integration/integration_lesspackets_travis.yml
+++ b/integration/integration_lesspackets_travis.yml
@@ -1,0 +1,35 @@
+atom_data_path: "/home/travis/tardis-refdata/atom_data/"
+
+# This section holds information about mechanism of saving the HTML
+# report of the tests.
+# "save_mode" is mandatory: It can be either "local" or "remote".
+report:
+  save_mode: "local"
+
+  # This section contains credentials for dokuwiki instance.
+  # It is mandatory if "save_mode" is "remote", else can be removed.
+  dokuwiki:
+    url: "http://opensupernova.org/~karandesai96/integration/"
+    username: "private"
+    password: "private"
+
+  # If "save_mode" is "local", a sub directory will be made in this
+  # directory according to commit hash (shortened), and it will contain
+  # the complete report content.
+  reportpath:  "/home/travis/tardis-refdata/integration/reports/"
+
+
+# Path to directory where reference HDF files will be generated and
+# saved during the test run. Use "--generate-reference" flag in command
+# line args for the purpose, for other cases this will denote path
+# to the directory containing reference HDF files.
+reference:  "/home/travis/tardis-refdata/integration/reference_lesspackets/"
+
+# Speeds up test execution by reducing amount of packets per iteration,
+# useful for debugging problems in testing infrastructure itself.
+# Use "--less-packets" in command line args, for other cases this will be
+# simply ignored. This section is not mandatory.
+less_packets:
+  no_of_packets: 400
+  last_no_of_packets: 1000
+

--- a/integration/reference_lesspackets/at.h5
+++ b/integration/reference_lesspackets/at.h5
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a11a089ab6a7e236c3b0979d2ce2df958de28f228c8a236b948047515c84e693
+size 180442263

--- a/integration/reference_lesspackets/paper1_downbranch.h5
+++ b/integration/reference_lesspackets/paper1_downbranch.h5
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6f72902c7de37acf34cdda001263839ffd5ca9e0c4ee54ccf646486ae176a79d
+size 327092651

--- a/integration/reference_lesspackets/paper1_macroatom.h5
+++ b/integration/reference_lesspackets/paper1_macroatom.h5
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cc98cb4c09cf086c4fd148c57a32756d4f5c7d3bfa005ede989fad21747f69f1
+size 440050749

--- a/integration/reference_lesspackets/paper1_scatter.h5
+++ b/integration/reference_lesspackets/paper1_scatter.h5
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:56d31bc29ae6d42b052e196709f714a0c3a4d11ad37c371baf4f7bdb52d2be83
+size 260890742

--- a/integration/reference_lesspackets/w7.h5
+++ b/integration/reference_lesspackets/w7.h5
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6c4e39d00b81758f6dd3e0d9f706c1c7e9eb9514b55c2466f7f95bed26d2c383
+size 159347273


### PR DESCRIPTION
This PR provides the basic infrastructure and reference data for the integration test suite that is resurrected in the Tardis PR #871.

- [ ] add yml config files
- [x] add reference data for test runs with --less-packets
- [ ] add reference data for full runs