### PR TITLE
Add a workflow to sync Azure Repos mirror

### DIFF
--- a/.github/workflows/sync-mirror.yml
+++ b/.github/workflows/sync-mirror.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Clone mirror repository
         run: |
-          git clone --bare https://tardis-sn@dev.azure.com/tardis-sn/TARDIS/_git/tardis-refdata
+          git -c http.extraHeader="Authorization: Basic ${B64_PAT}" clone --bare https://tardis-sn@dev.azure.com/tardis-sn/TARDIS/_git/tardis-refdata
 
       - name: Set upstream remote
         run: |
@@ -39,4 +39,4 @@ jobs:
       - name: Push changes to mirror
         run: |
           cd tardis-refdata.git
-          git -c http.extraHeader="Authorization: Basic ${B64_PAT}" push origin --all
+          git push origin --all

--- a/.github/workflows/sync-mirror.yml
+++ b/.github/workflows/sync-mirror.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Azure identity
         run: |
           MY_PAT=${{ secrets.AZURE_TOKEN }}
-          B64_PAT=$(printf ":$MY_PAT" | base64)
+          B64_PAT=$(printf "epassaro15:$MY_PAT" | base64)
 
       - name: Clone mirror repository
         run: |

--- a/.github/workflows/sync-mirror.yml
+++ b/.github/workflows/sync-mirror.yml
@@ -8,10 +8,6 @@ on:
     branches:
       - master
 
-  pull_request:
-    branches:
-      - master
-
 jobs:
   sync:
     runs-on: ubuntu-latest

--- a/.github/workflows/sync-mirror.yml
+++ b/.github/workflows/sync-mirror.yml
@@ -1,3 +1,6 @@
+# For more information on how to use this pipeline please refer to:
+# http://tardis-sn.github.io/tardis/development/continuous_integration.html
+
 name: sync-mirror
 
 on:

--- a/.github/workflows/sync-mirror.yml
+++ b/.github/workflows/sync-mirror.yml
@@ -16,14 +16,9 @@ jobs:
   sync:
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Azure identity
-        run: |
-          MY_PAT=${{ secrets.AZURE_TOKEN }}
-          B64_PAT=$(printf "epassaro15:$MY_PAT" | base64)
-
       - name: Clone mirror repository
         run: |
-          git -c http.extraHeader="Authorization: Basic ${B64_PAT}" clone --bare https://tardis-sn@dev.azure.com/tardis-sn/TARDIS/_git/tardis-refdata
+          git clone --bare https://tardis-sn@dev.azure.com/tardis-sn/TARDIS/_git/tardis-refdata
 
       - name: Set upstream remote
         run: |
@@ -39,4 +34,6 @@ jobs:
       - name: Push changes to mirror
         run: |
           cd tardis-refdata.git
-          git -c http.extraHeader="Authorization: Basic ${B64_PAT}" git push origin --all
+          MY_PAT=${{ secrets.AZURE_TOKEN }}
+          B64_PAT=$(printf ":$MY_PAT" | base64)
+          git -c http.extraHeader="Authorization: Basic ${B64_PAT}" push origin --all

--- a/.github/workflows/sync-mirror.yml
+++ b/.github/workflows/sync-mirror.yml
@@ -39,4 +39,4 @@ jobs:
       - name: Push changes to mirror
         run: |
           cd tardis-refdata.git
-          git push origin --all
+          git -c http.extraHeader="Authorization: Basic ${B64_PAT}" git push origin --all

--- a/.github/workflows/sync-mirror.yml
+++ b/.github/workflows/sync-mirror.yml
@@ -1,0 +1,39 @@
+name: sync-mirror
+
+on:
+  push:
+    branches:
+      - master
+
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Azure identity
+        run: |
+          MY_PAT=${{ secrets.AZURE_TOKEN }}
+          B64_PAT=$(printf ":$MY_PAT" | base64)
+
+      - name: Clone mirror repository
+        run: |
+          git clone --bare https://tardis-sn@dev.azure.com/tardis-sn/TARDIS/_git/tardis-refdata
+
+      - name: Set upstream remote
+        run: |
+          cd tardis-refdata.git
+          git remote add --mirror=fetch upstream https://github.com/tardis-sn/tardis-refdata.git
+          git fetch upstream --tags
+
+      - name: Fetch LFS objects
+        run: |
+          cd tardis-refdata.git 
+          git lfs fetch upstream --all
+
+      - name: Push changes to mirror
+        run: |
+          cd tardis-refdata.git
+          git -c http.extraHeader="Authorization: Basic ${B64_PAT}" push origin --all

--- a/README.md
+++ b/README.md
@@ -2,3 +2,6 @@
 ![Github](https://img.shields.io/github/license/tardis-sn/tardis-refdata)
 
 TARDIS repo for reference data for the integration tests
+
+> **IMPORTANT**: This repository is mirrored at `https://tardis-sn@dev.azure.com/tardis-sn/TARDIS/_git/tardis-refdata`
+  and synced automatically through a pipeline located at `.github/workflows/sync-mirror.yml`.

--- a/README.md
+++ b/README.md
@@ -3,5 +3,6 @@
 
 TARDIS repo for reference data for the integration tests
 
-> **IMPORTANT**: This repository is mirrored at `https://tardis-sn@dev.azure.com/tardis-sn/TARDIS/_git/tardis-refdata`
+> This repository is mirrored at `https://tardis-sn@dev.azure.com/tardis-sn/TARDIS/_git/tardis-refdata`
   and synced automatically through a pipeline located at `.github/workflows/sync-mirror.yml`.
+  <br><br> **Always check if binary files are tracked by Git LFS before pushing changes.**


### PR DESCRIPTION
## Description
A workflow to automatically update the reference data mirror every time something is pushed to the `master` branch.

Follows mostly [this guide](https://docs.microsoft.com/en-us/azure/devops/repos/git/import-git-repository?view=azure-devops#can-i-import-updates-if-the-source-changes-later).