### PR TITLE
push non-lfs files first

### DIFF
--- a/.github/workflows/sync-mirror.yml
+++ b/.github/workflows/sync-mirror.yml
@@ -33,4 +33,5 @@ jobs:
           MY_PAT=${{ secrets.AZURE_TOKEN }}
           B64_PAT=$(printf ":$MY_PAT" | base64)
           git config --local http.version HTTP/1.1
+          git -c http.extraHeader="Authorization: Basic ${B64_PAT}" push origin --all
           git -c http.extraHeader="Authorization: Basic ${B64_PAT}" lfs push origin --all


### PR DESCRIPTION
Last commit didn't update the notebook nor the workflow file. Maybe this happened because no LFS files were modified recently. I'm not completely sure, but this PR should not make any harm.