### PR TITLE
Updated test data to include formal integral values

### DIFF
--- a/unit_test_data.h5
+++ b/unit_test_data.h5
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:873d1bf57b48e2e82f2fbc692760b4cf26bcb7801aed2ff1a1517f8d62301fdc
-size 87100160
+oid sha256:8a0897f1148ef2ff973baee521c2dfd1d409196857f5dd625c4d77343cfbfbd8
+size 112643432


### PR DESCRIPTION
The PR aims to update the reference data for formal integral tests which have been enabled by the associated PR in the tardis repositor (link [here](https://github.com/tardis-sn/tardis/pull/1499)).