### PR TITLE
pickle5 patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,7 @@ TARDIS repo for reference data for the integration tests
   <br><br> **Always check if binary files are tracked by Git LFS before pushing changes.**
 
 
-**Contribution guidelines **
- 
-  https://tardis-sn.github.io/tardis/CONTRIBUTING.html
-  
-  By redirecting to this link, you can find the contribution guidelines
+## Contribution guidelines
+
+By redirecting to [this link](https://tardis-sn.github.io/tardis/CONTRIBUTING.html),
+you can find the contribution guidelines.

--- a/notebooks/ref_data_compare.ipynb
+++ b/notebooks/ref_data_compare.ipynb
@@ -82,6 +82,7 @@
    "outputs": [],
    "source": [
     "import os\n",
+    "import sys\n",
     "import shutil\n",
     "import tempfile\n",
     "import subprocess\n",
@@ -117,6 +118,20 @@
    "metadata": {},
    "source": [
     "## Define classes and functions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# data pickled with protocol 5 can't be opened with `python<3.8.3`, use the backport\n",
+    "\n",
+    "if sys.version_info < (3, 8, 3):\n",
+    "    import pickle5\n",
+    "\n",
+    "    sys.modules[\"pickle\"] = pickle5"
    ]
   },
   {


### PR DESCRIPTION
- patch `pickle5` issue (see https://github.com/tardis-sn/tardis/pull/1535)
- fix wrongly displayed README.md