### PR TITLE
Added Testing Data for RPacket Tracking 

### DIFF
--- a/rpacket_tracking.h5
+++ b/rpacket_tracking.h5
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:aa4868d0d268932b05adf4df3545c9f769626f36be60b61c7d70b6c42dcefe8e
+size 969288


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
This PR aims to add the required testing data for the testing suite of rpacket tracking. Required for PR[#1776](https://github.com/tardis-sn/tardis/pull/1776) to function.

**Type of change**
<!--- Put an `x` in all the boxes that apply -->
- [ ] Bug fix. <!-- non-breaking change which fixes an issue -->
- [x] New feature. <!-- non-breaking change which adds functionality -->
- [ ] Breaking change. <!-- fix or feature that would cause existing functionality to not work as expected -->
- [ ] None of the above. <!-- please describe -->

**Checklist**
<!--- Put an `x` in all the boxes that apply -->
- [ ] My change requires a change to the documentation.
    - [ ] I have updated the documentation accordingly.
    - [ ] (optional) I have built the documentation on my fork following [the instructions](https://tardis-sn.github.io/tardis/development/documentation_preview.html).
- [x] I have assigned and requested two reviewers for this pull request.
