### PR TITLE
Set contents of temporary file if reference data does not match in `ref_data_compare_from_paths.ipynb`

### DIFF
--- a/notebooks/ref_data_compare_from_paths.ipynb
+++ b/notebooks/ref_data_compare_from_paths.ipynb
@@ -456,6 +456,22 @@
     "                 tmp2['/test_runner_simple/spectrum_virtual/_frequency'][:-1], \n",
     "                 tmp2['/test_runner_simple/spectrum_virtual/luminosity'])"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if False in tt.match.values or None in tt.match.values:\n",
+    "    print(\"Reference files do not match, setting contents of tmp file to zero.\")\n",
+    "    with open('/tmp/refdata_compare_result', 'w+') as file:\n",
+    "        file.write('0')\n",
+    "else:\n",
+    "    print(\"Reference files match.\")\n",
+    "    with open('/tmp/refdata_compare_result', 'w+') as file:\n",
+    "        file.write('1')   "
+   ]
   }
  ],
  "metadata": {

--- a/notebooks/ref_data_compare_from_paths.ipynb
+++ b/notebooks/ref_data_compare_from_paths.ipynb
@@ -9,7 +9,6 @@
     "import os\n",
     "import sys\n",
     "import shutil\n",
-    "import tempfile\n",
     "import subprocess\n",
     "import numpy as np\n",
     "import pandas as pd\n",
@@ -465,12 +464,12 @@
    "source": [
     "if False in tt.match.values or None in tt.match.values:\n",
     "    print(\"Reference files do not match, setting contents of tmp file to zero.\")\n",
-    "    with open('refdata_compare_result', 'w+') as file:\n",
-    "        file.write('REFDATA COMPARISON FAILED')\n",
+    "    with open('refdata_compare_result', 'w+') as fh:\n",
+    "        fh.write('REFDATA COMPARISON FAILED')\n",
     "else:\n",
     "    print(\"Reference files match.\")\n",
-    "    with open('refdata_compare_result', 'w+') as file:\n",
-    "        file.write('REFDATA COMPARISON SUCCEEDED')   "
+    "    with open('refdata_compare_result', 'w+') as fh:\n",
+    "        fh.write('REFDATA COMPARISON SUCCEEDED')   "
    ]
   }
  ],

--- a/notebooks/ref_data_compare_from_paths.ipynb
+++ b/notebooks/ref_data_compare_from_paths.ipynb
@@ -465,12 +465,12 @@
    "source": [
     "if False in tt.match.values or None in tt.match.values:\n",
     "    print(\"Reference files do not match, setting contents of tmp file to zero.\")\n",
-    "    with open('/tmp/refdata_compare_result', 'w+') as file:\n",
-    "        file.write('0')\n",
+    "    with open('refdata_compare_result', 'w+') as file:\n",
+    "        file.write('REFDATA COMPARISON FAILED')\n",
     "else:\n",
     "    print(\"Reference files match.\")\n",
-    "    with open('/tmp/refdata_compare_result', 'w+') as file:\n",
-    "        file.write('1')   "
+    "    with open('refdata_compare_result', 'w+') as file:\n",
+    "        file.write('REFDATA COMPARISON SUCCEEDED')   "
    ]
   }
  ],


### PR DESCRIPTION
### :pencil: Description

**Type:** :beetle: `bugfix` 
<!-- Write a complete description of your changes, including the necessary context or any piece of information required to understand your work.

Also, link issues affected by this pull request by using the keywords: `close`, `closes`, `closed`, `fix`, `fixes`, `fixed`, `resolve`, `resolves` or `resolved`. 
-->
This PR changes the `ref_data_compare_from_paths.ipynb` notebook to set the contents of a file in the `/tmp` directory to zero if the datasets do not match. The bridge workflow(https://github.com/tardis-sn/carsus/pull/313) then checks the contents of this file and fails if zero is present.
An alternative to this could have been raising an error if the datasets failed to match- but nbconvert didn't allow converting notebooks to HTML if they had errors, which is why we had to go with this.

### :pushpin: Resources

Examples, notebooks, and links to useful references.


### :vertical_traffic_light: Testing

How did you test these changes?

- [X] Testing pipeline
- [ ] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [x] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
