### PR TITLE
Add Luminosity vs Wavelength plots to `ref_data_compare` notebook

### DIFF
--- a/notebooks/ref_data_compare.ipynb
+++ b/notebooks/ref_data_compare.ipynb
@@ -45,7 +45,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -72,7 +72,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2018-08-02T12:09:13.639421Z",
@@ -89,6 +89,7 @@
     "import numpy as np\n",
     "import pandas as pd\n",
     "import matplotlib.pyplot as plt\n",
+    "from astropy.constants import c\n",
     "from bokeh.plotting import figure, show, ColumnDataSource\n",
     "from bokeh.layouts import gridplot\n",
     "from bokeh.models.tools import HoverTool\n",
@@ -106,7 +107,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -122,7 +123,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -136,7 +137,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2018-08-02T09:58:38.546226Z",
@@ -166,7 +167,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2018-08-02T12:29:57.536422Z",
@@ -284,7 +285,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -309,7 +310,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -318,7 +319,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2018-08-02T12:30:01.760461Z",
@@ -339,7 +340,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2018-08-02T12:30:19.494810Z",
@@ -354,7 +355,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2018-08-02T12:31:18.320558Z",
@@ -368,13 +369,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2018-08-02T12:31:22.806199Z",
      "start_time": "2018-08-02T12:31:22.707055Z"
     },
-    "scrolled": false
+    "scrolled": true
    },
    "outputs": [],
    "source": [
@@ -396,7 +397,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -461,11 +462,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [],
    "source": [
-    "def compare_spectrum(ref1_nu, ref1_L, ref2_nu, ref2_L, mpl_backend=False):\n",
+    "def compare_spectrum(ref1_nu, ref1_lam, ref1_L, ref2_nu, ref2_lam, ref2_L, mpl_backend=False):\n",
     "    \n",
     "    if mpl_backend:\n",
     "        plt.figure(figsize=(14, 6))\n",
@@ -510,8 +511,31 @@
     "    q.yaxis.formatter.precision = 1\n",
     "    q.add_tools(hover)\n",
     "    \n",
+    "    r = figure()\n",
+    "    spectrum_wav1 = ColumnDataSource(pd.DataFrame.from_records({'x': ref1_lam.values, \n",
+    "                                                            'y': ref1_L}))\n",
+    "    spectrum_wav2 = ColumnDataSource(pd.DataFrame.from_records({'x': ref2_lam.values, \n",
+    "                                                            'y': ref2_L}))\n",
+    "    r.line('x', 'y', source=spectrum_wav1, legend_label='ref 1')\n",
+    "    r.line('x', 'y', source=spectrum_wav2, legend_label='ref 2', color='#ff7f0e')\n",
+    "    r.xaxis.axis_label = \"lambda\"\n",
+    "    r.yaxis.axis_label = \"L\"\n",
+    "    r.xaxis.formatter.precision = 1\n",
+    "    r.yaxis.formatter.precision = 1\n",
+    "    r.legend.click_policy=\"hide\"\n",
+    "    r.add_tools(hover)\n",
     "    \n",
-    "    plot = gridplot([p, q], ncols=2, plot_width=420, plot_height=360)\n",
+    "    s = figure()\n",
+    "    lum_ratio = ColumnDataSource(pd.DataFrame.from_records({'x': ref1_lam.values, \n",
+    "                                                            'y': ref1_L.values/ref2_L.values}))\n",
+    "    s.circle('x', 'y', size=1, source=lum_ratio)\n",
+    "    s.xaxis.axis_label = \"lambda\"\n",
+    "    s.yaxis.axis_label = \"L ref 1 / L ref 2\"\n",
+    "    s.xaxis.formatter.precision = 1\n",
+    "    s.yaxis.formatter.precision = 1\n",
+    "    s.add_tools(hover)\n",
+    "    \n",
+    "    plot = gridplot([p, q, r, s], ncols=2, plot_width=420, plot_height=360)\n",
     "    \n",
     "    show(plot)"
    ]
@@ -525,7 +549,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -544,7 +568,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -558,8 +582,10 @@
    "outputs": [],
    "source": [
     "compare_spectrum(tmp1['/test_runner_simple/spectrum/_frequency'][:-1], \n",
+    "                 tmp1['/test_runner_simple/spectrum/wavelength'],\n",
     "                 tmp1['/test_runner_simple/spectrum/luminosity'],\n",
     "                 tmp2['/test_runner_simple/spectrum/_frequency'][:-1], \n",
+    "                 tmp2['/test_runner_simple/spectrum/wavelength'],\n",
     "                 tmp2['/test_runner_simple/spectrum/luminosity'])"
    ]
   },
@@ -570,8 +596,10 @@
    "outputs": [],
    "source": [
     "compare_spectrum(tmp1['/test_runner_simple_integral_macroatom_interp/spectrum/_frequency'][:-1], \n",
+    "                 tmp1['/test_runner_simple_integral_macroatom_interp/spectrum/wavelength'],\n",
     "                 tmp1['/test_runner_simple_integral_macroatom_interp/spectrum_integrated/luminosity'],\n",
     "                 tmp2['/test_runner_simple_integral_macroatom_interp/spectrum/_frequency'][:-1], \n",
+    "                 tmp2['/test_runner_simple_integral_macroatom_interp/spectrum/wavelength'],\n",
     "                 tmp2['/test_runner_simple_integral_macroatom_interp/spectrum_integrated/luminosity'])"
    ]
   },
@@ -582,8 +610,10 @@
    "outputs": [],
    "source": [
     "compare_spectrum(tmp1['/test_runner_simple_integral_macroatom/spectrum/_frequency'][:-1], \n",
+    "                 tmp1['/test_runner_simple_integral_macroatom/spectrum_integrated/wavelength'],\n",
     "                 tmp1['/test_runner_simple_integral_macroatom/spectrum_integrated/luminosity'],\n",
     "                 tmp2['/test_runner_simple_integral_macroatom/spectrum/_frequency'][:-1], \n",
+    "                 tmp2['/test_runner_simple_integral_macroatom/spectrum_integrated/wavelength'],\n",
     "                 tmp2['/test_runner_simple_integral_macroatom/spectrum_integrated/luminosity'])"
    ]
   },
@@ -593,9 +623,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "compare_spectrum(tmp1['/test_runner_simple_integral_downbranch/spectrum/_frequency'][:-1], \r\n",
-    "                 tmp1['/test_runner_simple_integral_downbranch/spectrum_integrated/luminosity'],\r\n",
-    "                 tmp2['/test_runner_simple_integral_downbranch/spectrum/_frequency'][:-1], \r\n",
+    "compare_spectrum(tmp1['/test_runner_simple_integral_downbranch/spectrum/_frequency'][:-1], \n",
+    "                 tmp1['/test_runner_simple_integral_downbranch/spectrum/wavelength'],\n",
+    "                 tmp1['/test_runner_simple_integral_downbranch/spectrum_integrated/luminosity'],\n",
+    "                 tmp2['/test_runner_simple_integral_downbranch/spectrum/_frequency'][:-1], \n",
+    "                 tmp2['/test_runner_simple_integral_downbranch/spectrum/wavelength'],\n",
     "                 tmp2['/test_runner_simple_integral_downbranch/spectrum_integrated/luminosity'])"
    ]
   },
@@ -606,8 +638,10 @@
    "outputs": [],
    "source": [
     "compare_spectrum(tmp1['/test_runner_simple/spectrum_virtual/_frequency'][:-1], \n",
+    "                 tmp1['/test_runner_simple/spectrum_virtual/wavelength'],\n",
     "                 tmp1['/test_runner_simple/spectrum_virtual/luminosity'],\n",
     "                 tmp2['/test_runner_simple/spectrum_virtual/_frequency'][:-1], \n",
+    "                 tmp2['/test_runner_simple/spectrum_virtual/wavelength'],\n",
     "                 tmp2['/test_runner_simple/spectrum_virtual/luminosity'])"
    ]
   },
@@ -642,7 +676,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.6"
+   "version": "3.8.16"
   },
   "toc": {
    "nav_menu": {},

--- a/notebooks/ref_data_compare.ipynb
+++ b/notebooks/ref_data_compare.ipynb
@@ -89,7 +89,6 @@
     "import numpy as np\n",
     "import pandas as pd\n",
     "import matplotlib.pyplot as plt\n",
-    "from astropy.constants import c\n",
     "from bokeh.plotting import figure, show, ColumnDataSource\n",
     "from bokeh.layouts import gridplot\n",
     "from bokeh.models.tools import HoverTool\n",
@@ -662,7 +661,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },


### PR DESCRIPTION
### :pencil: Description

**Type:** :sunny: `enhancement`

This PR adds plots for Luminosity vs wavelength in addition to the existing Luminosity vs frequency plots.

Closes #62 



### :vertical_traffic_light: Testing

How did you test these changes?

- [x] Testing pipeline
- [ ] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [x] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

@atharva-2001 @jamesgillanders 
