### PR TITLE
Add Luminosity vs Wavelength plots to `ref_data_compare_from_paths` notebook

### DIFF
--- a/notebooks/ref_data_compare_from_paths.ipynb
+++ b/notebooks/ref_data_compare_from_paths.ipynb
@@ -310,7 +310,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def compare_spectrum(ref1_nu, ref1_L, ref2_nu, ref2_L, mpl_backend=False):\n",
+    "def compare_spectrum(ref1_nu, ref1_lam, ref1_L, ref2_nu, ref2_lam, ref2_L, mpl_backend=False):\n",
     "    \n",
     "    if mpl_backend:\n",
     "        plt.figure(figsize=(14, 6))\n",

--- a/notebooks/ref_data_compare_from_paths.ipynb
+++ b/notebooks/ref_data_compare_from_paths.ipynb
@@ -355,8 +355,31 @@
     "    q.yaxis.formatter.precision = 1\n",
     "    q.add_tools(hover)\n",
     "    \n",
+    "    r = figure()\n",
+    "    spectrum_wav1 = ColumnDataSource(pd.DataFrame.from_records({'x': ref1_lam.values, \n",
+    "                                                            'y': ref1_L}))\n",
+    "    spectrum_wav2 = ColumnDataSource(pd.DataFrame.from_records({'x': ref2_lam.values, \n",
+    "                                                            'y': ref2_L}))\n",
+    "    r.line('x', 'y', source=spectrum_wav1, legend_label='ref 1')\n",
+    "    r.line('x', 'y', source=spectrum_wav2, legend_label='ref 2', color='#ff7f0e')\n",
+    "    r.xaxis.axis_label = \"lambda\"\n",
+    "    r.yaxis.axis_label = \"L\"\n",
+    "    r.xaxis.formatter.precision = 1\n",
+    "    r.yaxis.formatter.precision = 1\n",
+    "    r.legend.click_policy=\"hide\"\n",
+    "    r.add_tools(hover)\n",
     "    \n",
-    "    plot = gridplot([p, q], ncols=2, plot_width=420, plot_height=360)\n",
+    "    s = figure()\n",
+    "    lum_ratio = ColumnDataSource(pd.DataFrame.from_records({'x': ref1_lam.values, \n",
+    "                                                            'y': ref1_L.values/ref2_L.values}))\n",
+    "    s.circle('x', 'y', size=1, source=lum_ratio)\n",
+    "    s.xaxis.axis_label = \"lambda\"\n",
+    "    s.yaxis.axis_label = \"L ref 1 / L ref 2\"\n",
+    "    s.xaxis.formatter.precision = 1\n",
+    "    s.yaxis.formatter.precision = 1\n",
+    "    s.add_tools(hover)\n",
+    "    \n",
+    "    plot = gridplot([p, q, r, s], ncols=2, plot_width=420, plot_height=360)\n",
     "    \n",
     "    show(plot)"
    ]
@@ -403,8 +426,10 @@
    "outputs": [],
    "source": [
     "compare_spectrum(tmp1['/test_runner_simple/spectrum/_frequency'][:-1], \n",
+    "                 tmp1['/test_runner_simple/spectrum/wavelength'],\n",
     "                 tmp1['/test_runner_simple/spectrum/luminosity'],\n",
     "                 tmp2['/test_runner_simple/spectrum/_frequency'][:-1], \n",
+    "                 tmp2['/test_runner_simple/spectrum/wavelength'],\n",
     "                 tmp2['/test_runner_simple/spectrum/luminosity'])"
    ]
   },
@@ -415,8 +440,10 @@
    "outputs": [],
    "source": [
     "compare_spectrum(tmp1['/test_runner_simple_integral_macroatom_interp/spectrum/_frequency'][:-1], \n",
+    "                 tmp1['/test_runner_simple_integral_macroatom_interp/spectrum/wavelength'],\n",
     "                 tmp1['/test_runner_simple_integral_macroatom_interp/spectrum_integrated/luminosity'],\n",
     "                 tmp2['/test_runner_simple_integral_macroatom_interp/spectrum/_frequency'][:-1], \n",
+    "                 tmp2['/test_runner_simple_integral_macroatom_interp/spectrum/wavelength'],\n",
     "                 tmp2['/test_runner_simple_integral_macroatom_interp/spectrum_integrated/luminosity'])"
    ]
   },
@@ -427,8 +454,10 @@
    "outputs": [],
    "source": [
     "compare_spectrum(tmp1['/test_runner_simple_integral_macroatom/spectrum/_frequency'][:-1], \n",
+    "                 tmp1['/test_runner_simple_integral_macroatom/spectrum_integrated/wavelength'],\n",
     "                 tmp1['/test_runner_simple_integral_macroatom/spectrum_integrated/luminosity'],\n",
     "                 tmp2['/test_runner_simple_integral_macroatom/spectrum/_frequency'][:-1], \n",
+    "                 tmp2['/test_runner_simple_integral_macroatom/spectrum_integrated/wavelength'],\n",
     "                 tmp2['/test_runner_simple_integral_macroatom/spectrum_integrated/luminosity'])"
    ]
   },
@@ -439,8 +468,10 @@
    "outputs": [],
    "source": [
     "compare_spectrum(tmp1['/test_runner_simple_integral_downbranch/spectrum/_frequency'][:-1], \n",
+    "                 tmp1['/test_runner_simple_integral_downbranch/spectrum/wavelength'],\n",
     "                 tmp1['/test_runner_simple_integral_downbranch/spectrum_integrated/luminosity'],\n",
     "                 tmp2['/test_runner_simple_integral_downbranch/spectrum/_frequency'][:-1], \n",
+    "                 tmp2['/test_runner_simple_integral_downbranch/spectrum/wavelength'],\n",
     "                 tmp2['/test_runner_simple_integral_downbranch/spectrum_integrated/luminosity'])"
    ]
   },
@@ -451,8 +482,10 @@
    "outputs": [],
    "source": [
     "compare_spectrum(tmp1['/test_runner_simple/spectrum_virtual/_frequency'][:-1], \n",
+    "                 tmp1['/test_runner_simple/spectrum_virtual/wavelength'],\n",
     "                 tmp1['/test_runner_simple/spectrum_virtual/luminosity'],\n",
     "                 tmp2['/test_runner_simple/spectrum_virtual/_frequency'][:-1], \n",
+    "                 tmp2['/test_runner_simple/spectrum_virtual/wavelength'],\n",
     "                 tmp2['/test_runner_simple/spectrum_virtual/luminosity'])"
    ]
   },
@@ -475,7 +508,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -489,7 +522,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.13"
+   "version": "3.8.16"
   },
   "toc": {
    "nav_menu": {},


### PR DESCRIPTION
### :pencil: Description
:vertical_traffic_light: `testing` 
Related to https://github.com/tardis-sn/tardis-refdata/issues/62
Adds graphs to the other notebook.

### :pushpin: Resources

Examples, notebooks, and links to useful references.


### :vertical_traffic_light: Testing

How did you test these changes?

- [ ] Testing pipeline
- [ ] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [ ] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
